### PR TITLE
Fix missing library include for clang

### DIFF
--- a/source/helper.cpp
+++ b/source/helper.cpp
@@ -26,6 +26,7 @@
 #include <core.hpp>
 #include <helper.hpp>
 
+#include <cstring>
 #include <iostream>
 
 // Each commit split just keeps getting more and more complex...


### PR DESCRIPTION
Clang does not see the `cstring` library in the helper file - This causes compilation to fail on linux:
```
clang++ -std=c++17 -O2 -Wall -Wpedantic -I"include" source/helper.cpp -c -o build/helper.o
source/helper.cpp:182:25: error: use of undeclared identifier 'strchr'
        while (NULL != (here = strchr(here, '\\'))) {
```

Adding `cstring` as a library to the file solves this.